### PR TITLE
fix: fix the sampling seed setting

### DIFF
--- a/src/backends/csa.py
+++ b/src/backends/csa.py
@@ -825,7 +825,7 @@ extern "C" const char clang_analyzerAPIVersionString[] =
         # Sample the reports
         filtered_keys = []
         sample_size = min(sampled_num, len(clustered_report_dir))
-        logger.warning(f"Sample size: {sample_size}")
+        logger.warning(f"Sample size: {sample_size} by seed {seed}")
 
         for key in clustered_report_dir.keys():
             if any(pattern in key for pattern in ["_include_"]):
@@ -833,15 +833,13 @@ extern "C" const char clang_analyzerAPIVersionString[] =
                 continue
             filtered_keys.append(key)
 
-        if len(filtered_keys) < sampled_num:
-            logger.warning(
-                f"Not enough ({sampled_num - len(filtered_keys)}) keys starting with 'drivers/'..."
-            )
+        if len(filtered_keys) < sample_size:
+            logger.warning(f"Not enough ({sample_size - len(filtered_keys)}) keys")
             other_keys = [
                 key for key in clustered_report_dir.keys() if key not in filtered_keys
             ]
             filtered_keys.extend(
-                random.sample(other_keys, sampled_num - len(filtered_keys))
+                random.sample(other_keys, sample_size - len(filtered_keys))
             )
 
         selected_keys = random.sample(filtered_keys, sample_size)

--- a/src/checker_refine.py
+++ b/src/checker_refine.py
@@ -1093,7 +1093,7 @@ def _process_reports(
 ) -> List[ReportData]:
     """Process and extract reports from kernel scan."""
     try:
-        seed = attempt_id if last_scan_id else 0
+        seed = attempt_id if (last_scan_id is not None) else 0
         reports, total_report = global_config.backend.extract_reports(
             kernel_report_dir,
             kernel_report_dir.parent / "reports",


### PR DESCRIPTION
This pull request makes minor improvements to the report sampling logic and seed initialization in the codebase. The changes clarify how the sample size and seed are logged and fix a potential bug in seed assignment when processing reports.

Sampling logic and logging improvements:

* The log message for the sample size in `extract_reports` now includes the random seed for better traceability.
* The warning about insufficient keys now correctly compares against the actual sample size, and the logic for sampling additional keys uses the correct value.

Seed initialization fix:

* In `_process_reports`, the seed is now set to `attempt_id` only if `last_scan_id` is not `None`, ensuring the seed is assigned as intended.