### PR TITLE
fix(checker_scan): remove erroneous parentheses when accessing target…

### DIFF
--- a/src/checker_scan.py
+++ b/src/checker_scan.py
@@ -84,7 +84,7 @@ def scan_batch_checkers(checker_dict, arch="x86"):
     comd_prefix += f"-o {output_dir_str} "
     olddefcmd = comd_prefix + f"make LLVM=1 ARCH={arch} olddefconfig"
 
-    global_config.target().checkout_commit(
+    global_config.target.checkout_commit(
         commit, is_before=False, olddefcmd=olddefcmd, arch=arch
     )
 


### PR DESCRIPTION
… property

In `scan_batch_checkers`, the code incorrectly calls `global_config.target()` as if it were a method. However, `target` is a `@property` that returns a `TargetFactory` instance (e.g., `Linux`). Invoking it with parentheses leads to `TypeError: 'Linux' object is not callable`.

This change removes the unnecessary parentheses, correctly accessing the property and calling `checkout_commit` on the returned object.

Fixes: TypeError during scan mode when using Linux target.